### PR TITLE
Use prior 4.6.14 docker image for the moment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
   runstages:
     working_directory: ~/repo
     docker:
-      - image: continuumio/miniconda3:latest
+      - image: continuumio/miniconda3:4.6.14
     steps:
       - checkout
       - run:


### PR DESCRIPTION
Latest miniconda3 docker images appear to have removed conda from their default path,
possibly requiring an explicit activation? I'm not sure the recommended command to call
and what sequence that should be done in, but reverting to a previous image should get
the bot running again in the interim?