### PR TITLE
Revert "Use prior 4.6.14 docker image for the moment"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
   runstages:
     working_directory: ~/repo
     docker:
-      - image: continuumio/miniconda3:4.6.14
+      - image: continuumio/miniconda3:latest
     steps:
       - checkout
       - run:


### PR DESCRIPTION
Reverts regro/circle_worker#5, since https://github.com/ContinuumIO/docker-images/pull/148 may have put back the PATH entry to make it work as expected. Will see on merge I guess.