### PR TITLE
populate versions folder

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,14 +92,7 @@ jobs:
             cd cf-graph
             source activate run_env
 
-            conda-forge-tick --run 2
-      - run:
-          name: populate versions
-          command: |
-            cd cf-graph
-            source activate run_env
-
-            conda-forge-tick --run 7     
+            conda-forge-tick --run 2  
       - run:
           name: run migrations
           command: |
@@ -210,6 +203,59 @@ jobs:
           command: |
             python bump_bot_team.py run_pr_update
 
+  run_versions_update:
+    working_directory: ~/repo
+    docker:
+      - image: continuumio/miniconda3:latest
+    steps:
+      - checkout
+      - run:
+          name: Update Conda
+          command: |
+            conda config --set always_yes True
+            conda config --prepend channels conda-forge
+            conda update --all
+            conda install --quiet --yes --file requirements.txt
+      - run:
+          name: Git user
+          command: |
+            git config --global user.name regro-cf-autotick-bot
+            git config --global user.email circleci@cf-graph.regro.github.com
+      - run:
+          name: Clone and Setup
+          command: |
+            export START_TIME=$(date +%s)
+            export TIMEOUT=7200
+            set -e
+            git clone https://github.com/regro/cf-scripts.git
+            cd cf-scripts
+            # remove/comment to run on master
+            # git fetch origin --verbose
+            # git checkout origin/v1
+            export GIT_FULL_HASH=$(git rev-parse HEAD)
+            conda create -n run_env --quiet --file requirements/run
+            source activate run_env
+            conda info
+            conda config --show-sources
+            conda list --show-channel-urls
+            python setup.py develop
+            cd ..
+            git clone --depth=1 https://github.com/regro/cf-graph-countyfair.git cf-graph
+            git clone --depth=1 https://github.com/conda-forge/conda-forge-pinning-feedstock.git
+      - run:
+          name: populate versions
+          command: |
+            cd cf-graph
+            source activate run_env
+            conda-forge-tick --run 7
+      - run:
+          name: deploy
+          when: always
+          command: |
+            cd cf-graph
+            source activate run_env
+            conda-forge-tick --run -1
+            
   run_audit:
     working_directory: ~/repo
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -342,3 +342,4 @@ workflows:
     jobs:
       - run_audit
       - pacemaker
+      - run_versions_update

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,6 +94,13 @@ jobs:
 
             conda-forge-tick --run 2
       - run:
+          name: populate versions
+          command: |
+            cd cf-graph
+            source activate run_env
+
+            conda-forge-tick --run 7     
+      - run:
           name: run migrations
           command: |
             export START_TIME=$(date +%s)


### PR DESCRIPTION
As an extension of [1027], this is the first try to add the `new_update_upstream_versions` to circle workers and integrate with the bot environment.

[1027]: https://github.com/regro/cf-scripts/pull/1027